### PR TITLE
remove ml.LabeledPoint from PySpark and annotate ml.LabeledPoint

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/LabeledPoint.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/LabeledPoint.scala
@@ -19,6 +19,7 @@ package org.apache.spark.ml.feature
 
 import scala.beans.BeanInfo
 
+import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.ml.linalg.Vector
 
 /**
@@ -27,8 +28,10 @@ import org.apache.spark.ml.linalg.Vector
  * @param label Label for this data point.
  * @param features List of features for this data point.
  */
+@Since("2.0.0")
+@Experimental
 @BeanInfo
-case class LabeledPoint(label: Double, features: Vector) {
+case class LabeledPoint(@Since("2.0.0") label: Double, @Since("2.0.0") features: Vector) {
   override def toString: String = {
     s"($label,$features)"
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -1623,24 +1623,6 @@ private[spark] object SerDe extends Serializable {
     }
   }
 
-  // Pickler for ML LabeledPoint
-  private[python] class MLLabeledPointPickler extends BasePickler[MLLabeledPoint] {
-
-    override protected def packageName = PYSPARK_ML_PACKAGE
-
-    def saveState(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
-      val point: MLLabeledPoint = obj.asInstanceOf[MLLabeledPoint]
-      saveObjects(out, pickler, point.label, point.features)
-    }
-
-    def construct(args: Array[Object]): Object = {
-      if (args.length != 2) {
-        throw new PickleException("should be 2")
-      }
-      new MLLabeledPoint(args(0).asInstanceOf[Double], args(1).asInstanceOf[NewVector])
-    }
-  }
-
   // Pickler for Rating
   private[python] class RatingPickler extends BasePickler[Rating] {
 
@@ -1684,7 +1666,6 @@ private[spark] object SerDe extends Serializable {
         new NewSparseMatrixPickler().register()
         new NewSparseVectorPickler().register()
         new LabeledPointPickler().register()
-        new MLLabeledPointPickler().register()
         new RatingPickler().register()
         initialized = true
       }

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -29,8 +29,7 @@ from pyspark.ml.util import JavaMLReadable, JavaMLWritable
 from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaTransformer, _jvm
 from pyspark.mllib.common import inherit_doc
 
-__all__ = ['LabeledPoint',
-           'Binarizer',
+__all__ = ['Binarizer',
            'Bucketizer',
            'ChiSqSelector', 'ChiSqSelectorModel',
            'CountVectorizer', 'CountVectorizerModel',
@@ -58,36 +57,6 @@ __all__ = ['LabeledPoint',
            'VectorIndexer', 'VectorIndexerModel',
            'VectorSlicer',
            'Word2Vec', 'Word2VecModel']
-
-
-class LabeledPoint(object):
-
-    """
-    Class that represents the features and labels of a data point.
-
-    :param label:
-      Label for this data point.
-    :param features:
-      Vector of features for this point (NumPy array, list,
-      pyspark.ml.linalg.SparseVector, or scipy.sparse column matrix).
-
-    Note: 'label' and 'features' are accessible as class attributes.
-
-    .. versionadded:: 1.0.0
-    """
-
-    def __init__(self, label, features):
-        self.label = float(label)
-        self.features = _convert_to_vector(features)
-
-    def __reduce__(self):
-        return (LabeledPoint, (self.label, self.features))
-
-    def __str__(self):
-        return "(" + ",".join((str(self.label), str(self.features))) + ")"
-
-    def __repr__(self):
-        return "LabeledPoint(%s, %s)" % (self.label, self.features)
 
 
 @inherit_doc

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1409,8 +1409,8 @@ class VectorUDTTests(MLlibTestCase):
             self.assertEqual(v, self.udt.deserialize(self.udt.serialize(v)))
 
     def test_infer_schema(self):
-        rdd = self.sc.parallelize([LabeledPoint(1.0, self.dv1),
-                                   LabeledPoint(0.0, self.sv1)])
+        rdd = self.sc.parallelize([Row(label=1.0, features=self.dv1),
+                                   Row(label=0.0, features=self.sv1)])
         df = rdd.toDF()
         schema = df.schema
         field = [f for f in schema.fields if f.name == "features"][0]


### PR DESCRIPTION
`LabeledPoint` is not used in `pyspark.ml`. This PR removes it and its pickler as well.
