### PR TITLE
Add manually given primary author at the head of author list

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -142,6 +142,9 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
         distinct_authors[0])
     if primary_author == "":
         primary_author = distinct_authors[0]
+    else:
+        # When primary author is specified manually, put it at the head of author list.
+        distinct_authors.insert(0, primary_author)
 
     commits = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
                       '--pretty=format:%h [%an] %s']).split("\n\n")


### PR DESCRIPTION
## What changes were proposed in this pull request?

When primary author is manually given, we should put it at the head of author list. So it can be lead author with `Lead-authored-by` and other authors are co-authors with `Co-authored-by`.

